### PR TITLE
Fix: Send attachments with correct filename, filetype and as attachment (not inline)

### DIFF
--- a/src/main/java/com/premiumminds/webapp/utils/mailer/SimpleMailer.java
+++ b/src/main/java/com/premiumminds/webapp/utils/mailer/SimpleMailer.java
@@ -41,7 +41,12 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class SimpleMailer extends AbstractMailer {
+	
+	private static final Logger log = LoggerFactory.getLogger(SimpleMailer.class);
 
 	private Address from;
 	private String[] filenames;
@@ -172,7 +177,7 @@ public class SimpleMailer extends AbstractMailer {
 					try {
 						contentType = Files.probeContentType(file.toPath());
 					} catch (IOException e) {
-						// ignore exception while determining file type
+						log.info("Failed to determine content type of attachment ["+filename+"]: ", e);
 					}
 					messageAttachment.addHeader("Content-Type", contentType);
 

--- a/src/main/java/com/premiumminds/webapp/utils/mailer/SimpleMailer.java
+++ b/src/main/java/com/premiumminds/webapp/utils/mailer/SimpleMailer.java
@@ -18,10 +18,14 @@
  */
 package com.premiumminds.webapp.utils.mailer;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Properties;
+
 import javax.activation.DataHandler;
 import javax.activation.DataSource;
 import javax.activation.FileDataSource;
@@ -29,6 +33,7 @@ import javax.mail.Address;
 import javax.mail.BodyPart;
 import javax.mail.MessagingException;
 import javax.mail.Multipart;
+import javax.mail.Part;
 import javax.mail.Session;
 import javax.mail.Transport;
 import javax.mail.internet.InternetAddress;
@@ -154,12 +159,22 @@ public class SimpleMailer extends AbstractMailer {
 			if (null != getAttachmentsFiles()) {
 
 				for (String filename : getAttachmentsFiles()) {
-					DataSource source = new FileDataSource(filename);
-
+					File file = new File(filename);
+					DataSource source = new FileDataSource(file);
+					
 					BodyPart messageAttachment = new MimeBodyPart();
-
 					messageAttachment.setDataHandler(new DataHandler(source));
-					messageAttachment.setFileName(filename);
+					
+					messageAttachment.setFileName(file.getName());
+					messageAttachment.setDisposition(Part.ATTACHMENT);
+
+					String contentType = source.getContentType();
+					try {
+						contentType = Files.probeContentType(file.toPath());
+					} catch (IOException e) {
+						// ignore exception while determining file type
+					}
+					messageAttachment.addHeader("Content-Type", contentType);
 
 					mp.addBodyPart(messageAttachment);
 				}


### PR DESCRIPTION
This fixes some minor issues in SimpleMailer email attachments:
- the attachment name appeared as the full path to that file in sender's system;
- attachment file types always had "Content-type" equal to that of the email message, so plaintext or html, which means regardless of true file type an email client (ie Thunderbird) would default to trying to open any file as text/html;
- attachment content was displayed inline
